### PR TITLE
Limit clone depth for builds to 1 to speed up builds

### DIFF
--- a/build-templates/build-package.job.yml
+++ b/build-templates/build-package.job.yml
@@ -12,6 +12,8 @@ jobs:
   pool: 
     vmImage: ${{ parameters.vmImage }}
   steps:
+    - checkout: self
+      fetchDepth: 1
     - template: build-solution.steps.yml
       parameters:
         buildConfiguration: ${{ parameters.buildConfiguration }}


### PR DESCRIPTION
We only need the latest version of every file to verify changes or build a new package.